### PR TITLE
Use apt-get to install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM convox/ruby
 
-RUN apk update 
-RUN apk add nginx
+RUN apt-get -y install nginx
 
 ENV PORT 5000
 


### PR DESCRIPTION
We switched from Alpine to Ubuntu, but still call `apk` in the Dockerfile.

```
Step 2 : RUN apk update
 ---> Running in 21a7667928a7
 /bin/sh: 1: apk: not found
 The command '/bin/sh -c apk update' returned a non-zero code: 127
```
