### PR TITLE
Fix nginx.pid path

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,7 +3,7 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 error_log /proc/self/fd/2;
-pid /var/run/nginx/nginx.pid;
+pid /run/nginx.pid;
 
 http {
   server {


### PR DESCRIPTION
/var/run/nginx isn't created by the ubuntu nginx package which means nginx will fail to start in containers built from this image. Ubuntu expects to use /run/nginx.pid (which is included in the default nginx.conf).
