### PR TITLE
Avoid pauses due to localhost resolution/IPv6

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -12,7 +12,7 @@ http {
   }
 
   upstream app {
-    server localhost:5000;
+    server 127.0.0.1:5000;
   }
 
   server {


### PR DESCRIPTION
When using localhost for the upstream address nginx will print warnings that it was unable to connect to [:::1]:5000 and there are noticeable delays while answering requests. Using 127.0.0.1 stops the warnings and the delays.
