### PR TITLE
Remove hardcoded port variable

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -1,3 +1,3 @@
 #!/bin/sh
 nginx &
-env PORT=5000 ruby config.ru
+ruby config.ru


### PR DESCRIPTION
The PORT variable is already set by the Dockerfile, duplicating it here will cause confusion.
